### PR TITLE
DFC Tweaks

### DIFF
--- a/Magic/Importer.lua
+++ b/Magic/Importer.lua
@@ -28,7 +28,9 @@ local Card=setmetatable({n=1,hwfd=true,image=false,json='',position={0,0,0},snap
       c.name=c.name:gsub('"','')..'\n'..c.type_line:gsub(' // .*','')..' '..c.cmc..'CMC'
       --Oracle text Handling for Split/DFCs
       if c.card_faces then
-        for _,f in ipairs(c.card_faces)do c.oracle=c.oracle..c.name:gsub('"','\'')..'\n'..setOracle(f)end
+        for _,f in ipairs(c.card_faces)do
+          f.name=f.name:gsub('"','')..'\n'..f.type_line:gsub(' // .*','')..' '..c.cmc..'CMC'
+          c.oracle=c.oracle..f.name:gsub('"','\'')..'\n'..setOracle(f)..(_== 1 and '\n' or '')end
       else c.oracle=setOracle(c)end
       
       local n=t.n


### PR DESCRIPTION
Instead of starting right after power/toughness/loyalty, there's a line break before the second face's description.
Instead of showing NAME1//NAME 2 \n TYPE 1 for both faces, now it's NAME 1 \n TYPE 1 and NAME 2 \n TYPE 2

The CMC is still the same for both faces, and the sub for // is still there I guess.