### PR TITLE
Life Tracker for Multiple Games

### DIFF
--- a/Magic/LifeTracker.lua
+++ b/Magic/LifeTracker.lua
@@ -1,7 +1,7 @@
 --By Amuzet
 mod_name,version='LifeTracker',1
 author='76561198045776458'
-function updateSave()self.script_state=JSON.encode({['c']=count})end
+function updateSave()self.script_state=JSON.encode({['c']=count,['subs']=subs})end
 function wait(t)local s=os.time()repeat coroutine.yield(0)until os.time()>s+t end
 function sL(l,n)self.editButton({index=0,label='\n'..l..'\n'..(n or'')})end
 function option(o,c,a)
@@ -22,7 +22,7 @@ function click_changeValue(obj, color, val)
       local gl='lost'
       if C1>C2 then gl='gained'end
       if C1~=C2 then sL(count)local t=txt:format(gl,math.abs(count-C2),count)
-        printToAll(t,self.getColorTint())log(t)end
+        printToSome(t,self.getColorTint())log(t)end
       C2=nil end return 1 end
   startLuaCoroutine(self,'clickCoroutine')
   updateSave()
@@ -35,12 +35,20 @@ local lCheck={
   ['double_my_life_']=function(n,c)if c==owner then return count*2^n,'doubled their life this many times'end end,
   ['set_life_']=function(n,c)if c==owner then return n,'Life total changed by '..math.abs(n-count)..'. Setting it to'end end,
   ['drain_']=function(n,c)if c==owner then return count+n,'drained everyone for'else return count-n,false,true end end,
-  ['extort_']=function(n,c)if c==owner then for _,p in pairs(Player.getPlayers())do if p.seated and p.color~=owner then count=count+n end end return count,'extorted everyone for'else return count-n,false,true end end,
+  ['extort_']=function(n,c)if c==owner then for _,p in pairs(Player.getPlayers())do if p.seated and p.color~=owner and subs[p.color] then count=count+n end end return count,'extorted everyone for'else return count-n,false,true end end,
   -- ['test_']=function(n,c)return count end,
 }
 
+function colorToggleSubscribe(c)
+  subs[c] = not subs[c]
+  if subs[c] then printToColor(c..' subscribed to '..self.getDescription(), c) else printToColor(c..' unsubscribed from '..self.getDescription(), c) end
+end
+function printToSome(text,tint)
+  for _, c in ipairs({'White','Blue','Red','Purple','Pink','Green','Orange','Yellow','Teal','Brown'}) do if subs[c] then printToColor(text,c,tint) end end
+end
 function onChat(msg,player)
   if msg:find('[ _]%d+')then
+    if not subs[player.color] then return true end
     local m=msg:lower():gsub(' ','_')
     local a,sl,t,n=false,false,'',tonumber(m:match('%d+'))
     
@@ -52,7 +60,7 @@ function onChat(msg,player)
     
     updateSave()
     if t and t~=''then
-      printToAll(player.color..'[999999] '..t..' [-]'..n,self.getColorTint())
+      printToSome(player.color..'[999999] '..t..' [-]'..n,self.getColorTint())
       sL(count,count-JSON.decode(self.script_state).c)
       return false end
 end end
@@ -63,7 +71,7 @@ function onload(s)
   txt=owner..' [888888]%s %s '..ref_type..'.[-] |%s|'
   local clr=stringColorToRGB(owner)
   self.setColorTint(clr)
-  if s~=''then local ld=JSON.decode(s);count=ld.c else count=0 end
+  if s~=''then local ld=JSON.decode(s);count=ld.c;subs=ld.subs else count=0;subs={White=true,Blue=true,Red=true,Purple=true,Pink=true,Green=true,Orange=true,Yellow=true,Teal=true,Brown=true} end
   self.createButton({tooltip='Click to increase\nRight click to decrease',click_function='option',function_owner=self,label='\n'..count..'\n',
       position={-x,0,0},scale={0.60,1,0.60},height=800,width=2100,font_size=2000,rotation={0,90,0},color=g,font_color=clr})
   for i,v in ipairs({{n=1,l='+',p={0,y,z}},{n=-1,l='-',p={0,y,-z}}})do
@@ -78,6 +86,7 @@ function onload(s)
     self.addContextMenuItem(m,function(p)if p~=owner then return end mode=k
         self.createInput({position={-x*2,y,0},input_function='ipt',function_owner=self,tooltip=m..' Input\nOwner`s final edit will be used.',alignment=3,validation=2,width=500,height=323,font_size=300,rotation={0,90,0},color=g,font_color=clr})
       end)end
+  self.addContextMenuItem('Toggle Life Alerts', colorToggleSubscribe, false)
 end
 function ipt(o,p,v,s)
   if not s and p==owner then

--- a/Magic/LifeTracker.lua
+++ b/Magic/LifeTracker.lua
@@ -21,8 +21,8 @@ function click_changeValue(obj, color, val)
     if C2 and C1==count then
       local gl='lost'
       if C1>C2 then gl='gained'end
-      if C1~=C2 then sL(count)local t=txt:format(gl,math.abs(count-C2),count)
-        printToSome(t,self.getColorTint())log(t)end
+      sL(count)local t=txt:format(gl,math.abs(count-C2),count)
+      printToSome(t,self.getColorTint())log(t)
       C2=nil end return 1 end
   startLuaCoroutine(self,'clickCoroutine')
   updateSave()


### PR DESCRIPTION
Allows players to unsubscribe from a Life Tracker, removing them from calculations for player numbers and leaving them out of broadcast messages.  
Changes behavior for the life change helper text such that making 0 change does not leave the text visible.